### PR TITLE
Loose peer dependency on moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "peerDependencies": {
     "vue": "^2.6.10",
-    "moment": "=2.24.0"
+    "moment": "2.x"
   },
   "devDependencies": {
     "@babel/core": "^7.4.4",
@@ -81,7 +81,7 @@
     "rollup-plugin-vue": "^5.0.0",
     "semver": "^6.0.0",
     "vue": "^2.5.16",
-    "moment": "=2.24.0",
+    "moment": "2.x",
     "vue-eslint-parser": "^6.0.4",
     "vue-jest": "^4.0.0-beta.2",
     "vue-template-compiler": "^2.6.10"


### PR DESCRIPTION
So the lib could handle the changes in moment versions in other repositories more gracefully.